### PR TITLE
Fixed packages overflowing into media section

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -184,7 +184,6 @@ ul#nav li a:active{
 }
 #Packages {
   position: relative;
-  height: 800px;
   min-height: 500px;
   padding: 50px;
   width: 100%;


### PR DESCRIPTION
Simple error, fixed height on #packages was removed 